### PR TITLE
Fix equipment URLs and admin import

### DIFF
--- a/traknor/admin/user_admin.py
+++ b/traknor/admin/user_admin.py
@@ -3,7 +3,8 @@
 from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin as BaseUserAdmin
 
-from traknor.infrastructure.models.user import User
+# Use the user model defined in the accounts infrastructure package.
+from traknor.infrastructure.accounts.user import User
 
 
 @admin.register(User)

--- a/traknor/presentation/equipment/urls.py
+++ b/traknor/presentation/equipment/urls.py
@@ -1,9 +1,10 @@
-from django.urls import path, include
+from django.urls import include, path
 from rest_framework.routers import DefaultRouter
 
 from .views import EquipmentViewSet
 
-app_name = "equipment"
+# Do not namespace these routes so reverse('equipment-list') works without a
+# prefix. Tests expect the un-namespaced route name.
 
 router = DefaultRouter()
 router.register(r'', EquipmentViewSet, basename='equipment')


### PR DESCRIPTION
## Summary
- fix import path for the custom User admin
- remove namespace from equipment URLs so `reverse('equipment-list')` works

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855b965c074832c8515526b9a30aef8