### PR TITLE
Add equipment CSV importer

### DIFF
--- a/traknor/application/services/equipment_importer.py
+++ b/traknor/application/services/equipment_importer.py
@@ -1,0 +1,53 @@
+import csv
+import io
+from typing import List, Dict, Tuple
+
+from django.core.exceptions import ValidationError
+
+from traknor.infrastructure.equipment.models import EquipmentModel
+
+HEADERS = [
+    "name",
+    "description",
+    "type",
+    "location",
+    "criticality",
+    "status",
+]
+
+
+def import_from_csv(file) -> Tuple[int, List[Dict]]:
+    """Import equipments from a CSV file.
+
+    Parameters
+    ----------
+    file: UploadedFile or file-like object opened in binary mode
+        CSV file with UTF-8 encoding.
+
+    Returns
+    -------
+    Tuple[int, List[Dict]]
+        Number of created objects and a list of errors per line.
+    """
+    data = file.read().decode("utf-8")
+    reader = csv.DictReader(io.StringIO(data))
+
+    if reader.fieldnames != HEADERS:
+        return 0, [{"line": 1, "errors": "Invalid headers"}]
+
+    objects = []
+    errors: List[Dict] = []
+
+    for line_num, row in enumerate(reader, start=2):
+        obj = EquipmentModel(**row)
+        try:
+            obj.full_clean()
+            objects.append(obj)
+        except ValidationError as e:
+            errors.append({"line": line_num, "errors": e.message_dict})
+
+    if errors:
+        return 0, errors
+
+    EquipmentModel.objects.bulk_create(objects)
+    return len(objects), []

--- a/traknor/presentation/equipment/import_view.py
+++ b/traknor/presentation/equipment/import_view.py
@@ -1,0 +1,18 @@
+from rest_framework import status
+from rest_framework.views import APIView
+from rest_framework.response import Response
+
+from traknor.application.services.equipment_importer import import_from_csv
+
+
+class EquipmentImportView(APIView):
+    """Import equipments from a CSV file."""
+
+    def post(self, request):
+        csv_file = request.FILES.get("file")
+        if csv_file is None:
+            return Response({"detail": "No file provided"}, status=status.HTTP_400_BAD_REQUEST)
+
+        created, errors = import_from_csv(csv_file)
+        status_code = status.HTTP_200_OK if not errors else status.HTTP_400_BAD_REQUEST
+        return Response({"created": created, "errors": errors}, status=status_code)

--- a/traknor/presentation/equipment/tests.py
+++ b/traknor/presentation/equipment/tests.py
@@ -20,3 +20,34 @@ def test_create_and_list_equipment(client):
     response = client.get(url)
     assert response.status_code == 200
     assert response.json()[0]['name'] == 'AC 01'
+
+
+def _upload_csv(client, content: str):
+    from django.core.files.uploadedfile import SimpleUploadedFile
+
+    file = SimpleUploadedFile("eq.csv", content.encode("utf-8"), content_type="text/csv")
+    url = reverse("equipment:equipment-import")
+    return client.post(url, {"file": file})
+
+
+def test_import_valid_csv(client):
+    csv_data = (
+        "name,description,type,location,criticality,status\n"
+        "AC1,Desc,Split,Room,Alta,Operacional\n"
+        "AC2,Desc,Fancoil,Room,Média,Operacional\n"
+    )
+    response = _upload_csv(client, csv_data)
+    assert response.status_code == 200
+    assert response.json()["created"] == 2
+    assert response.json()["errors"] == []
+
+
+def test_import_csv_with_errors(client):
+    csv_data = (
+        "name,description,type,location,criticality,status\n"
+        "AC1,Desc,Invalid,Room,Alta,Operacional\n"
+    )
+    response = _upload_csv(client, csv_data)
+    assert response.status_code == 400
+    assert response.json()["created"] == 0
+    assert len(response.json()["errors"]) == 1

--- a/traknor/presentation/equipment/urls.py
+++ b/traknor/presentation/equipment/urls.py
@@ -2,10 +2,14 @@ from django.urls import include, path
 from rest_framework.routers import DefaultRouter
 
 from .views import EquipmentViewSet
+from .import_view import EquipmentImportView
+
+app_name = "equipment"
 
 router = DefaultRouter()
 router.register(r'', EquipmentViewSet, basename='equipment')
 
 urlpatterns = [
     path('', include(router.urls)),
+    path('import/', EquipmentImportView.as_view(), name='equipment-import'),
 ]


### PR DESCRIPTION
## Summary
- implement equipment CSV importer service
- expose POST `/api/equipment/import/` endpoint
- add tests for CSV import

## Testing
- `ruff check .`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6855f8fbcc04832ca518be613404e292