### PR TITLE
Implement email notification for completed work orders

### DIFF
--- a/traknor/application/services/work_order_service.py
+++ b/traknor/application/services/work_order_service.py
@@ -10,6 +10,7 @@ from traknor.infrastructure.models.work_order_history import (
     WorkOrderHistory as WorkOrderHistoryModel,
 )
 from traknor.infrastructure.accounts.user import User
+from traknor.infrastructure.notifications.email import send_work_order_completed
 
 
 def _to_domain(obj: WorkOrderModel) -> WorkOrder:
@@ -61,6 +62,7 @@ def update_status(work_order_id: int, new_status: str, changed_by: User) -> Work
     obj.status = new_status
     if new_status == "Concluída" and obj.completed_date is None:
         obj.completed_date = date.today()
+        send_work_order_completed(obj)
     obj.save()
     return _to_domain(obj)
 

--- a/traknor/infrastructure/notifications/__init__.py
+++ b/traknor/infrastructure/notifications/__init__.py
@@ -1,0 +1,1 @@
+"""Notification infrastructure utilities."""

--- a/traknor/infrastructure/notifications/email.py
+++ b/traknor/infrastructure/notifications/email.py
@@ -1,0 +1,12 @@
+from django.core.mail import send_mail
+from traknor.infrastructure.work_orders.models import WorkOrder
+
+
+def send_work_order_completed(work_order: WorkOrder) -> None:
+    """Send notification that a work order was completed."""
+    send_mail(
+        subject="Ordem de Serviço Concluída",
+        message=f"A Ordem de Serviço {work_order.code} foi concluída.",
+        from_email="noreply@example.com",
+        recipient_list=[work_order.created_by.email],
+    )

--- a/traknor/presentation/work_orders/tests.py
+++ b/traknor/presentation/work_orders/tests.py
@@ -147,3 +147,23 @@ def test_history_endpoint(api_client):
     assert len(data) == 2
     assert data[0]["new_status"] == "Concluída"
     assert data[1]["new_status"] == "Em Execução"
+
+
+def test_email_sent_on_completion(mailoutbox):
+    user, equip = _create_basic_objects()
+    wo = work_order_service.create(
+        {
+            "equipment": equip,
+            "priority": "Alta",
+            "scheduled_date": date.today(),
+            "created_by": user,
+            "description": "Teste",
+            "cost": 0,
+        }
+    )
+
+    work_order_service.update_status(wo.id, "Em Execução", user)
+    work_order_service.update_status(wo.id, "Concluída", user)
+
+    assert len(mailoutbox) == 1
+    assert mailoutbox[0].to == [user.email]


### PR DESCRIPTION
## Summary
- add new notification infrastructure module
- notify when a work order is completed
- test email notification on completion

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855fc271de0832ca4675ddd8cd93cf7