### PR TITLE
feat(SB11-Reports): geração de relatórios PDF/Excel

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,5 +38,6 @@ pytest
 - `/api/equipment/` – list and create equipment. Supports CSV import via `/import/` endpoint.
 - `/api/work-orders/` – manage work orders and view history.
 - `/api/dashboard/summary/` – dashboard metrics.
+- `/api/reports/` – generate PDF or Excel equipment/work order reports.
 
 Note: This repository is a Django backend. Node.js/TypeScript features mentioned in some tasks are not applicable.

--- a/config/urls.py
+++ b/config/urls.py
@@ -10,4 +10,5 @@ urlpatterns = [
     path("api/dashboard/", include("traknor.presentation.dashboard.urls")),
     path("api/pmoc/", include("traknor.presentation.pmoc.urls")),
     path("api/os/", include("traknor.presentation.os_api.urls")),
+    path("api/reports/", include("traknor.presentation.reports.urls")),
 ]

--- a/docs/openapi/index.yaml
+++ b/docs/openapi/index.yaml
@@ -8,6 +8,7 @@ paths:
   <<: { $ref: './pmoc.yaml#/paths' }
   <<: { $ref: './auth.yaml#/paths' }
   <<: { $ref: './dashboard.yaml#/paths' }
+  <<: { $ref: './report.yaml#/paths' }
 components:
   <<: { $ref: './asset.yaml#/components' }
   <<: { $ref: './workorder.yaml#/components' }

--- a/docs/openapi/report.yaml
+++ b/docs/openapi/report.yaml
@@ -1,0 +1,36 @@
+paths:
+  /api/reports/:
+    get:
+      summary: Generate reports
+      parameters:
+        - in: query
+          name: type
+          required: true
+          schema:
+            type: string
+            enum: [equipment, workorder]
+          description: Dataset type
+        - in: query
+          name: format
+          required: false
+          schema:
+            type: string
+            enum: [pdf, xlsx]
+          description: Output format
+        - in: query
+          name: from
+          required: false
+          schema:
+            type: string
+            format: date
+        - in: query
+          name: to
+          required: false
+          schema:
+            type: string
+            format: date
+      responses:
+        '200':
+          description: binary file
+        '400':
+          description: invalid params

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,7 @@ black
 ruff
 djangorestframework
 djangorestframework-simplejwt
+weasyprint>=60.0
+pandas>=2.0
+xlsxwriter>=3.2
 

--- a/traknor/application/services/report_service.py
+++ b/traknor/application/services/report_service.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Sequence
+
+from traknor.infrastructure.equipment.models import EquipmentModel
+from traknor.infrastructure.work_orders.models import WorkOrder
+
+
+class ReportService:
+    """Service to generate datasets for reports."""
+
+    @staticmethod
+    def get_dataset(
+        report_type: str,
+        *,
+        from_date: datetime | None = None,
+        to_date: datetime | None = None,
+    ) -> Sequence[dict]:
+        """Retrieve dataset by type and date range."""
+        if report_type == "equipment":
+            qs = EquipmentModel.objects.all()
+            if from_date:
+                qs = qs.filter(created_at__date__gte=from_date.date())
+            if to_date:
+                qs = qs.filter(created_at__date__lte=to_date.date())
+            return list(
+                qs.values(
+                    "id",
+                    "name",
+                    "description",
+                    "type",
+                    "location",
+                    "criticality",
+                    "status",
+                )
+            )
+        if report_type == "workorder":
+            qs = WorkOrder.objects.all()
+            if from_date:
+                qs = qs.filter(created_at__date__gte=from_date.date())
+            if to_date:
+                qs = qs.filter(created_at__date__lte=to_date.date())
+            return list(
+                qs.values(
+                    "id",
+                    "equipment__name",
+                    "description",
+                    "status",
+                    "created_at",
+                    "completed_date",
+                )
+            )
+        raise ValueError("invalid type")

--- a/traknor/infrastructure/reports/excel_renderer.py
+++ b/traknor/infrastructure/reports/excel_renderer.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from io import BytesIO
+from typing import Any
+
+import pandas as pd
+
+
+@dataclass
+class ExcelRenderer:
+    """Render datasets into Excel using pandas."""
+
+    @staticmethod
+    def render(context: dict[str, Any], sheet_name: str) -> bytes:
+        df = pd.DataFrame(context.get("rows", []))
+        output = BytesIO()
+        with pd.ExcelWriter(output, engine="xlsxwriter") as writer:
+            df.to_excel(writer, index=False, sheet_name=sheet_name)
+        return output.getvalue()

--- a/traknor/infrastructure/reports/pdf_renderer.py
+++ b/traknor/infrastructure/reports/pdf_renderer.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from django.template.loader import get_template
+from weasyprint import HTML
+
+
+@dataclass
+class PdfRenderer:
+    """Render HTML templates into PDF bytes using WeasyPrint."""
+
+    @staticmethod
+    def render(context: dict[str, Any], template_name: str) -> bytes:
+        template = get_template(template_name)
+        html = template.render(context)
+        return HTML(string=html).write_pdf()

--- a/traknor/infrastructure/reports/templates/equipment_report.html
+++ b/traknor/infrastructure/reports/templates/equipment_report.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title>Equipment Report</title>
+</head>
+<body>
+    <h1>{{ title }}</h1>
+    <table>
+        <thead>
+            <tr>
+                <th>ID</th>
+                <th>Name</th>
+                <th>Description</th>
+                <th>Type</th>
+                <th>Location</th>
+                <th>Criticality</th>
+                <th>Status</th>
+            </tr>
+        </thead>
+        <tbody>
+        {% for row in rows %}
+            <tr>
+                <td>{{ row.id }}</td>
+                <td>{{ row.name }}</td>
+                <td>{{ row.description }}</td>
+                <td>{{ row.type }}</td>
+                <td>{{ row.location }}</td>
+                <td>{{ row.criticality }}</td>
+                <td>{{ row.status }}</td>
+            </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+</body>
+</html>

--- a/traknor/infrastructure/reports/templates/workorder_report.html
+++ b/traknor/infrastructure/reports/templates/workorder_report.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title>Work Order Report</title>
+</head>
+<body>
+    <h1>{{ title }}</h1>
+    <table>
+        <thead>
+            <tr>
+                <th>ID</th>
+                <th>Equipment</th>
+                <th>Description</th>
+                <th>Status</th>
+                <th>Created</th>
+                <th>Completed</th>
+            </tr>
+        </thead>
+        <tbody>
+        {% for row in rows %}
+            <tr>
+                <td>{{ row.id }}</td>
+                <td>{{ row.equipment__name }}</td>
+                <td>{{ row.description }}</td>
+                <td>{{ row.status }}</td>
+                <td>{{ row.created_at }}</td>
+                <td>{{ row.completed_date }}</td>
+            </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+</body>
+</html>

--- a/traknor/presentation/reports/tests.py
+++ b/traknor/presentation/reports/tests.py
@@ -1,0 +1,17 @@
+import pytest
+from django.urls import reverse
+
+pytestmark = pytest.mark.django_db
+
+
+def test_missing_type_returns_400(client):
+    url = reverse("reports")
+    response = client.get(url)
+    assert response.status_code == 400
+
+
+def test_equipment_pdf(client):
+    url = reverse("reports") + "?type=equipment"
+    response = client.get(url)
+    assert response.status_code == 200
+    assert response["Content-Type"] == "application/pdf"

--- a/traknor/presentation/reports/urls.py
+++ b/traknor/presentation/reports/urls.py
@@ -1,0 +1,7 @@
+from django.urls import path
+
+from .views import ReportView
+
+urlpatterns = [
+    path("", ReportView.as_view(), name="reports"),
+]

--- a/traknor/presentation/reports/views.py
+++ b/traknor/presentation/reports/views.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from traknor.application.services.report_service import ReportService
+from traknor.infrastructure.reports.excel_renderer import ExcelRenderer
+from traknor.infrastructure.reports.pdf_renderer import PdfRenderer
+
+
+class ReportView(APIView):
+    """Generate equipment or work order reports in PDF or Excel."""
+
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request) -> Response:
+        report_type = request.query_params.get("type")
+        if not report_type:
+            return Response({"detail": "type is required"}, status=400)
+        format_ = request.query_params.get("format", "pdf")
+        try:
+            from_date = (
+                datetime.fromisoformat(request.query_params["from"])
+                if "from" in request.query_params
+                else None
+            )
+            to_date = (
+                datetime.fromisoformat(request.query_params["to"])
+                if "to" in request.query_params
+                else None
+            )
+        except ValueError:
+            return Response({"detail": "invalid date"}, status=400)
+
+        try:
+            rows = ReportService.get_dataset(
+                report_type, from_date=from_date, to_date=to_date
+            )
+        except ValueError:
+            return Response({"detail": "invalid type"}, status=400)
+
+        context: dict[str, Any] = {"title": "Report", "rows": rows}
+        if format_ == "xlsx":
+            data = ExcelRenderer.render(context, sheet_name="Report")
+            return Response(
+                data,
+                content_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            )
+        data = PdfRenderer.render(
+            context,
+            template_name=f"reports/{report_type}_report.html",
+        )
+        return Response(data, content_type="application/pdf")


### PR DESCRIPTION
## Contexto
Implementa endpoint `/api/reports/` para gerar relatórios de equipamentos ou ordens de serviço em PDF ou Excel.

## Mudanças
- Novo `ReportService` na camada application
- Renderizadores `PdfRenderer` e `ExcelRenderer`
- Templates HTML de relatório
- View `ReportView` e rota correspondente
- Documentação OpenAPI atualizada
- Dependências `weasyprint`, `pandas` e `xlsxwriter`

## Como testar
1. `GET /api/reports/?type=equipment` retorna PDF
2. `GET /api/reports/?type=workorder&format=xlsx` retorna planilha

✍️ Docs Atualizadas? ✅


------
https://chatgpt.com/codex/tasks/task_e_6856d9f76f10832c8b6a497878b5fd5a