### PR TITLE
feat(SB12-KPI): cálculo MTBF/MTTR no dashboard

### DIFF
--- a/docs/openapi/dashboard.yaml
+++ b/docs/openapi/dashboard.yaml
@@ -7,6 +7,67 @@ paths:
     get:
       summary: Retrieve KPIs
       tags: [Dashboard]
+      parameters:
+        - in: query
+          name: from
+          schema:
+            type: string
+            format: date
+        - in: query
+          name: to
+          schema:
+            type: string
+            format: date
+        - in: query
+          name: equipment_id
+          schema:
+            type: integer
+        - in: query
+          name: group_by
+          schema:
+            type: string
+            enum: [day, week, month]
       responses:
         "200":
           description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  range:
+                    type: object
+                    properties:
+                      from:
+                        type: string
+                        format: date
+                      to:
+                        type: string
+                        format: date
+                  mtbf:
+                    type: number
+                  mttr:
+                    type: number
+                  open_workorders:
+                    type: integer
+                  closed_workorders:
+                    type: integer
+                  series:
+                    type: object
+                    properties:
+                      labels:
+                        type: array
+                        items:
+                          type: string
+                      mtbf:
+                        type: array
+                        items:
+                          type: number
+                      mttr:
+                        type: array
+                        items:
+                          type: number
+                      closed:
+                        type: array
+                        items:
+                          type: integer

--- a/traknor/domain/metrics/kpi_calculator.py
+++ b/traknor/domain/metrics/kpi_calculator.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, timedelta
+from typing import Iterable, List, Optional
+
+from traknor.domain.work_order import WorkOrder
+
+
+@dataclass
+class KPISeries:
+    """Time series data for KPIs."""
+
+    labels: List[str]
+    mtbf: List[float]
+    mttr: List[float]
+    closed: List[int]
+
+
+@dataclass
+class KPIResult:
+    """KPI data for a given range."""
+
+    range_from: date
+    range_to: date
+    mtbf: float
+    mttr: float
+    open_workorders: int
+    closed_workorders: int
+    series: Optional[KPISeries] = None
+
+
+def _calc_mtbf(workorders: Iterable[WorkOrder], start: date) -> float:
+    closed = [w for w in workorders if w.completed_date]
+    if not closed:
+        return 0.0
+    closed.sort(key=lambda w: w.completed_date)
+    prev = start
+    spans: List[float] = []
+    for wo in closed:
+        spans.append((wo.completed_date - prev).total_seconds() / 3600)
+        prev = wo.completed_date
+    return sum(spans) / len(spans)
+
+
+def _calc_mttr(workorders: Iterable[WorkOrder]) -> float:
+    durations = []
+    for w in workorders:
+        if w.completed_date and w.scheduled_date:
+            durations.append(
+                (w.completed_date - w.scheduled_date).total_seconds() / 3600
+            )
+    return sum(durations) / len(durations) if durations else 0.0
+
+
+def _series_labels(start: date, end: date, group_by: str) -> List[date]:
+    labels: List[date] = []
+    cur = start
+    if group_by == "day":
+        step = timedelta(days=1)
+        while cur <= end:
+            labels.append(cur)
+            cur += step
+    elif group_by == "week":
+        # align to week start (Monday)
+        cur -= timedelta(days=cur.weekday())
+        step = timedelta(days=7)
+        while cur <= end:
+            labels.append(cur)
+            cur += step
+    else:  # month
+        cur = cur.replace(day=1)
+        while cur <= end:
+            labels.append(cur)
+            if cur.month == 12:
+                cur = cur.replace(year=cur.year + 1, month=1)
+            else:
+                cur = cur.replace(month=cur.month + 1)
+    return labels
+
+
+def compute(
+    workorders: Iterable[WorkOrder],
+    start: date,
+    end: date,
+    *,
+    group_by: str | None = None,
+    open_count: int = 0,
+    closed_count: int = 0,
+) -> KPIResult:
+    """Compute KPI values for the given work orders."""
+
+    mtbf = _calc_mtbf(workorders, start)
+    mttr = _calc_mttr(workorders)
+    series_obj: KPISeries | None = None
+    if group_by:
+        labels_dates = _series_labels(start, end, group_by)
+        labels: List[str] = []
+        mtbf_list: List[float] = []
+        mttr_list: List[float] = []
+        closed_list: List[int] = []
+        for idx, label_date in enumerate(labels_dates):
+            if group_by == "day":
+                next_date = label_date + timedelta(days=1)
+                label = label_date.isoformat()
+            elif group_by == "week":
+                next_date = label_date + timedelta(days=7)
+                iso_year, iso_week, _ = label_date.isocalendar()
+                label = f"{iso_year}-W{iso_week:02d}"
+            else:
+                if label_date.month == 12:
+                    next_date = label_date.replace(year=label_date.year + 1, month=1)
+                else:
+                    next_date = label_date.replace(month=label_date.month + 1)
+                label = label_date.strftime("%Y-%m")
+
+            subset = [
+                w
+                for w in workorders
+                if w.completed_date and label_date <= w.completed_date < next_date
+            ]
+            labels.append(label)
+            mtbf_list.append(_calc_mtbf(subset, label_date))
+            mttr_list.append(_calc_mttr(subset))
+            closed_list.append(len(subset))
+        series_obj = KPISeries(
+            labels=labels, mtbf=mtbf_list, mttr=mttr_list, closed=closed_list
+        )
+
+    return KPIResult(
+        range_from=start,
+        range_to=end,
+        mtbf=mtbf,
+        mttr=mttr,
+        open_workorders=open_count,
+        closed_workorders=closed_count,
+        series=series_obj,
+    )

--- a/traknor/domain/metrics/tests/test_kpi_calculator.py
+++ b/traknor/domain/metrics/tests/test_kpi_calculator.py
@@ -1,0 +1,38 @@
+from datetime import date, timedelta
+from uuid import uuid4
+
+from traknor.domain.metrics.kpi_calculator import _calc_mtbf, _calc_mttr
+from traknor.domain.work_order import WorkOrder
+
+
+def _wo(closed: date, opened: date | None = None) -> WorkOrder:
+    return WorkOrder(
+        id=1,
+        code=uuid4(),
+        equipment_id=1,
+        status="Concluída",
+        priority="Alta",
+        scheduled_date=opened,
+        completed_date=closed,
+        created_by_id=1,
+        description="",
+        cost=0.0,
+    )
+
+
+def test_calc_mttr():
+    base = date(2025, 6, 1)
+    wos = [
+        _wo(base + timedelta(days=1), base),
+        _wo(base + timedelta(days=3), base + timedelta(days=2)),
+    ]
+    assert _calc_mttr(wos) == 1.0
+
+
+def test_calc_mtbf():
+    base = date(2025, 6, 1)
+    wos = [
+        _wo(base + timedelta(days=2)),
+        _wo(base + timedelta(days=5)),
+    ]
+    assert _calc_mtbf(wos, base) == 2.5

--- a/traknor/presentation/dashboard/tests.py
+++ b/traknor/presentation/dashboard/tests.py
@@ -83,11 +83,13 @@ def test_kpi_endpoint(client):
     token = login_resp.json()["access"]
 
     resp = client.get(
-        reverse("dashboard:kpis"), HTTP_AUTHORIZATION=f"Bearer {token}"
+        reverse("dashboard:kpis"),
+        HTTP_AUTHORIZATION=f"Bearer {token}",
+        data={"from": str(date.today() - timedelta(days=120)), "to": str(date.today())},
     )
     assert resp.status_code == 200
     data = resp.json()
-    assert "openOrders" in data
+    assert "open_workorders" in data
 
 
 def test_mtbf_calculation(client):

--- a/traknor/presentation/dashboard/views.py
+++ b/traknor/presentation/dashboard/views.py
@@ -2,6 +2,8 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from datetime import date
+
 from traknor.application.services.dashboard_service import (
     get_dashboard_summary,
     get_kpis,
@@ -24,5 +26,22 @@ class KPIView(APIView):
     permission_classes = [IsAuthenticated]
 
     def get(self, request):
-        data = get_kpis()
+        try:
+            from_param = request.query_params.get("from")
+            to_param = request.query_params.get("to")
+            eq_param = request.query_params.get("equipment_id")
+            group_by = request.query_params.get("group_by")
+
+            range_from = date.fromisoformat(from_param) if from_param else None
+            range_to = date.fromisoformat(to_param) if to_param else None
+            equipment_id = int(eq_param) if eq_param else None
+        except ValueError:
+            return Response({"error": "Invalid parameters"}, status=400)
+
+        data = get_kpis(
+            range_from=range_from,
+            range_to=range_to,
+            equipment_id=equipment_id,
+            group_by=group_by,
+        )
         return Response(data)


### PR DESCRIPTION
## Contexto
Adiciona cálculo dinâmico de KPIs (MTBF, MTTR, OS abertas/fechadas) com filtros de data e equipamento.

## Mudanças
- Novo módulo `kpi_calculator` para cálculo de métricas.
- Serviço de dashboard atualizado para aceitar filtros e gerar séries temporais.
- API `GET /api/dashboard/kpis/` passa a receber parâmetros `from`, `to`, `equipment_id` e `group_by`.
- Documentação OpenAPI revisada.
- Testes unitários para `kpi_calculator` e ajustes em testes de view.

## Como testar
1. Executar `pytest` (após instalar dependências).
2. Acessar `/api/dashboard/kpis/?from=2025-06-01&to=2025-06-21` autenticado e conferir valores.

✍️ Docs Atualizadas? ✅

------
https://chatgpt.com/codex/tasks/task_e_6856e0a0a500832c96924c5b9f172da7