### PR TITLE
chore(SB17-Types): relaxa mypy strict mode para desbloquear CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,10 @@ jobs:
         run: echo "DATABASE_URL=sqlite:///$(pwd)/ci.db.sqlite3" >> $GITHUB_ENV
       - name: Run migrations
         run: python manage.py migrate --noinput
+      - name: Run Ruff
+        run: ruff check . --select F,E,I
+      - name: Static type check
+        run: mypy .
       - name: Run tests with coverage
         run: |
           pytest
@@ -37,5 +41,3 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           files: ./coverage.xml
-      - name: Run Ruff
-        run: ruff check . --select F,E,I

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - SB13 OpenAPI auto-docs via drf-spectacular with CI coverage gate.
 - SB14 WorkOrder state machine with optimistic lock and soft delete.
 - SB15 test coverage 60 % with Codecov badge.
+### Changed
+- SB17 relax mypy strict mode to unblock CI
 ### Fixed
  - CI no longer fails when DATABASE_URL is unset (SB16).
  - OpenAPI CI errors corrected and validation command fixed (SB17).

--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ pytest
 ## Build & Quality
 
 [![Coverage](https://img.shields.io/codecov/c/github/ClimaTrak/TrakNor-Backend?label=coverage)](https://codecov.io/gh/ClimaTrak/TrakNor-Backend)
+## Quality Gates
+
+Atualmente o `mypy` roda em modo relaxado (`strict` desabilitado) para liberar o pipeline. Consulte a issue `chore/sbXX-enable-mypy-strict` para acompanhar a reativação.
+
 
 ## API Overview
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,3 +4,12 @@ line-length = 88
 
 [tool.ruff.lint]
 ignore = ["I001"]
+
+[tool.mypy]
+python_version = "3.11"
+strict = false
+ignore_missing_imports = true
+pretty = true
+show_error_codes = true
+allow_untyped_globals = true
+disable_error_code = ["var-annotated"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ drf-spectacular>=0.27
 drf-spectacular-sidecar
 pyyaml
 
+mypy


### PR DESCRIPTION
## Contexto
Relaxamento temporário do modo estrito do MyPy para que o pipeline volte a passar mesmo com a base legada.

## Mudanças
- Adicionada configuração `[tool.mypy]` no `pyproject.toml` desabilitando `strict` e ignorando imports faltantes.
- `requirements.txt` agora inclui `mypy`.
- Workflow de CI atualizado para executar `mypy .` sem `--strict`.
- README ganha seção **Quality Gates** explicando o modo relaxado.
- CHANGELOG atualizado com a entrada do SB17.

## Como testar
1. `pip install -r requirements.txt`
2. `ruff check .` e `mypy .`
3. `pytest`


------
https://chatgpt.com/codex/tasks/task_e_685732f902bc832cbebe6d6530b39cb5